### PR TITLE
fix!: URI encode username and password inputs

### DIFF
--- a/src/activities/CreateFmeService.ts
+++ b/src/activities/CreateFmeService.ts
@@ -91,8 +91,8 @@ export class CreateFmeService implements IActivityHandler {
 
                 // Generate a token
                 FMEServer.generateToken(
-                    username,
-                    password,
+                    encodeURIComponent(username),
+                    encodeURIComponent(password),
                     expiration || 60,
                     "minutes",
                     (token) => {


### PR DESCRIPTION
The Create FME Service activity now URI encodes the Username and Password inputs.

Closes #12 