### PR TITLE
feat!: add Get FME Info activity

### DIFF
--- a/src/activities/CreateFmeService.ts
+++ b/src/activities/CreateFmeService.ts
@@ -72,7 +72,7 @@ export class CreateFmeService implements IActivityHandler {
             return {
                 service: {
                     server: FMEServer,
-                    url,
+                    url: normalizedUrl,
                 },
             };
         } else if (username && password) {

--- a/src/activities/GetFmeInfo.ts
+++ b/src/activities/GetFmeInfo.ts
@@ -1,0 +1,54 @@
+import type { IActivityHandler } from "@geocortex/workflow/runtime/IActivityHandler";
+import { FmeService } from "../FmeService";
+
+export interface GetFmeInfoInputs {
+    /**
+     * @displayName FME Service
+     * @description The FME service.
+     * @required
+     */
+    service: FmeService;
+}
+
+export interface GetFmeInfoOutputs {
+    /**
+     * @description The FME server information.
+     */
+    result: {
+        build?: string;
+        currentTime?: string;
+        licenseManagement?: boolean;
+        timeZone?: string;
+        version?: string;
+    };
+}
+
+/**
+ * @displayName Get FME Info
+ * @category FME
+ * @description Retrieves build, version and time information about the FME server.
+ * @clientOnly
+ * @supportedApps EXB, GWV, GVH, WAB
+ */
+export class GetFmeInfo implements IActivityHandler {
+    async execute(inputs: GetFmeInfoInputs): Promise<GetFmeInfoOutputs> {
+        const { service } = inputs;
+        if (!service) {
+            throw new Error("service is required");
+        }
+
+        return new Promise((resolve) => {
+            service.server.customRequest(
+                `${service.url}/fmerest/v3/info`,
+                "GET",
+                (result) => {
+                    return resolve({
+                        result,
+                    });
+                },
+                "",
+                "application/x-www-form-urlencoded"
+            );
+        });
+    }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 // Activities will be re-exported from this file.
 export * from "./activities/CheckFmeJobStatus";
 export * from "./activities/CreateFmeService";
+export * from "./activities/GetFmeInfo";
 export * from "./activities/GetFmeWorkspaceParameters";
 export * from "./activities/RunFmeDataDownload";
 export * from "./activities/RunFmeJob";


### PR DESCRIPTION
Add Get FME Info activity.

Fix a bug where we would not normalize the FME server URL when creating the service with a token. This counts as a breaking change, but it is unlikely that anyone is using the URL output directly.